### PR TITLE
Fallback CRC checking for Specials and Development units

### DIFF
--- a/board/ipaccess/ipa9131/Makefile
+++ b/board/ipaccess/ipa9131/Makefile
@@ -28,7 +28,6 @@ obj-$(CONFIG_CMD_KEY)        += key.o
 obj-y        += secboot.o
 obj-y        += led.o
 obj-y        += ipa9131_fuse.o
-#TODO for now only compile this command in binaries that include usefull debug functions like printf
-obj-$(CONFIG_ML9131) += flash.o fimage.o security.o hash_sw.o asn1.o x509.o verify_image.o image.o ml9131.o
+obj-$(CONFIG_ML9131) += flash.o fimage.o security.o hash_sw.o asn1.o x509.o verify_image.o crc_image.o image.o ml9131.o
 
 endif

--- a/board/ipaccess/ipa9131/crc_image.c
+++ b/board/ipaccess/ipa9131/crc_image.c
@@ -1,0 +1,32 @@
+#include "crc_image.h"
+#include <common.h>
+
+
+
+
+static u32 ibncrc32(u32 crc, uint8_t *p, int len)
+{
+    int i;
+    crc = ~crc;
+
+    while (--len >= 0)
+    {
+        crc = crc ^ *p++;
+
+        for (i = 8; --i >= 0;)
+        {
+            crc = (crc >> 1) ^ (0xedb88320 & -(crc & 1));
+        }
+    }
+
+    return ~crc;
+}
+
+
+
+
+int crc_image(fimage_header_t * header)
+{
+    u32 crc = ibncrc32(0, ((uint8_t *)(header)) + sizeof(*header), header->code_size);
+    return crc == header->code_crc ? 0 : -1;
+}

--- a/board/ipaccess/ipa9131/crc_image.h
+++ b/board/ipaccess/ipa9131/crc_image.h
@@ -1,0 +1,8 @@
+#ifndef CRC_IMAGE_H_20150419
+#define CRC_IMAGE_H_20150419
+
+#include "fimage.h"
+
+extern int crc_image(fimage_header_t * header);
+
+#endif

--- a/board/ipaccess/ipa9131/fimage.h
+++ b/board/ipaccess/ipa9131/fimage.h
@@ -30,11 +30,11 @@ struct fimage_header_s
     unsigned int cert_chain_size;    /* Size of certificate chain */
     unsigned int ub_cookie_magic;    /* IBN cookie (identification ) */
     unsigned int ub_cookie_version;  /* IBN cookie version (identification ) */
-    unsigned int reserved_0;         /* Unused */
-    unsigned int reserved_1;         /* Unused */
+    unsigned int code_crc;           /* A crc32 over the code area of the IBN (for booting unsigned images) */
+    unsigned int unused;             /* Unused (for now) */
     unsigned int swversion;          /* IBN payload version (i.e. version of the wrapped software) */
     unsigned int revocation;         /* IBN revocation count */
-    unsigned int reserved_3;         /* Unused */
+    unsigned int reserved;           /* Reserved for runtime status tracking */
     unsigned int magic1;             /* IBN identification */
     unsigned int magic2;             /* IBN identification */
     unsigned int magic3;             /* IBN identification */

--- a/board/ipaccess/ipa9131/image.c
+++ b/board/ipaccess/ipa9131/image.c
@@ -8,6 +8,7 @@
 #include "fimage.h"
 #include "security.h"
 #include "verify_image.h"
+#include "crc_image.h"
 
 
 #define FIMAGE_MAX_REPLICA_COUNT 4
@@ -15,6 +16,7 @@
 #define IMAGE_LOAD_ERROR 42
 #define IMAGE_VERIFY_ERROR 43
 #define IMAGE_REVOKED_ERROR 44
+#define IMAGE_CRC_ERROR 45
 
 struct fimage_table_s
 {
@@ -91,8 +93,14 @@ int load_image(unsigned int start_block, unsigned int num_blocks, unsigned int i
     unsigned int image_load_address;
     unsigned int revocation_count;
     unsigned int i;
+    unsigned int oper_mode;
     fimage_header_t * most_suitable;
     fimage_header_t * fallback;
+
+    if (0 != read_operating_mode(&oper_mode))
+    {
+        return -1;
+    }
 
     read_board_revocation_count(&revocation_count);
 
@@ -130,16 +138,38 @@ int load_image(unsigned int start_block, unsigned int num_blocks, unsigned int i
 
         if (0 != verify_image(&fimage_table.images[i]))
         {
-            fimage_table.images[i].reserved = IMAGE_VERIFY_ERROR;
-            puts("Image failed verification\n");
-            continue;
+            if (oper_mode == SPECIALS_MODE || oper_mode == DEVELOPMENT_MODE)
+            {
+                if (0 != crc_image(&fimage_table.images[i]))
+                {
+                    fimage_table.images[i].reserved = IMAGE_CRC_ERROR;
+                    puts("Image failed CRC check\n");
+                    continue;
+                }
+
+                puts("Suppressing image verification failure as we are in either specials or development mode\n");
+            }
+            else
+            {
+                puts("Image failed verification\n");
+                fimage_table.images[i].reserved = IMAGE_VERIFY_ERROR;
+                continue;
+            }
         }
 
-        if (fimage_table.images[i].revocation > revocation_count)
+        if (oper_mode != SPECIALS_MODE && fimage_table.images[i].revocation > revocation_count)
         {
             fimage_table.images[i].reserved = IMAGE_REVOKED_ERROR;
-            puts("Image is revoked\n");
-            continue;
+
+            if (oper_mode == DEVELOPMENT_MODE)
+            {
+                puts("Suppressing image revoked error as we are in development mode\n");
+            }
+            else
+            {
+                puts("Image is revoked\n");
+                continue;
+            }
         }
     }
 

--- a/board/ipaccess/ipa9131/image.c
+++ b/board/ipaccess/ipa9131/image.c
@@ -118,26 +118,26 @@ int load_image(unsigned int start_block, unsigned int num_blocks, unsigned int i
 
     for (i = 0; i < fimage_table.entries; ++i)
     {
-        fimage_table.images[i].reserved_3 = 0;
+        fimage_table.images[i].reserved = 0;
 
         if (0 != flash_read_bytes((unsigned char *)image_load_address,
                                   fimage_table.images[i].source - sizeof(fimage_header_t),
                                   fimage_table.images[i].image_size + sizeof(fimage_header_t)))
         {
-            fimage_table.images[i].reserved_3 = IMAGE_LOAD_ERROR;
+            fimage_table.images[i].reserved = IMAGE_LOAD_ERROR;
             continue;
         }
 
         if (0 != verify_image(&fimage_table.images[i]))
         {
-            fimage_table.images[i].reserved_3 = IMAGE_VERIFY_ERROR;
+            fimage_table.images[i].reserved = IMAGE_VERIFY_ERROR;
             puts("Image failed verification\n");
             continue;
         }
 
         if (fimage_table.images[i].revocation > revocation_count)
         {
-            fimage_table.images[i].reserved_3 = IMAGE_REVOKED_ERROR;
+            fimage_table.images[i].reserved = IMAGE_REVOKED_ERROR;
             puts("Image is revoked\n");
             continue;
         }
@@ -159,7 +159,7 @@ int load_image(unsigned int start_block, unsigned int num_blocks, unsigned int i
 
     for (i = 0; i < fimage_table.entries; ++i)
     {
-        if (0 != fimage_table.images[i].reserved_3)
+        if (0 != fimage_table.images[i].reserved)
         {
             continue;
         }


### PR DESCRIPTION
This changeset allows a fallback to code area CRC checking to ensure that we load a U-Boot that has not been corrupted when in specials and development mode.

This also bypasses revocation count checks in specials mode and warns on revocation failure in development mode (rather than failing).
