### PR TITLE
Default to the current PHY address, falling back the the previous

### DIFF
--- a/include/configs/ipa9131.h
+++ b/include/configs/ipa9131.h
@@ -8,7 +8,10 @@
 
 #include "BSC9131RDB.h"
 
-/* #undef CONFIG_FIT_VERBOSE */
+#undef TSEC2_PHY_ADDR
+#define TSEC2_PHY_ADDR		1
+
+#undef CONFIG_FIT_VERBOSE
 
 /*
  * U-Boot execution will be controlled from an embedded OF tree
@@ -64,14 +67,14 @@
  */
 #define CONFIG_CMD_UBI
 #define CONFIG_RBTREE
-/* #define CONFIG_UBI_SILENCE_MSG */
+#define CONFIG_UBI_SILENCE_MSG
 
 /*
  * We will support UBIFS filesystems
  */
 #define CONFIG_CMD_UBIFS
 #define CONFIG_LZO
-/* #define CONFIG_UBIFS_SILENCE_MSG */
+#define CONFIG_UBIFS_SILENCE_MSG
 
 
 /*

--- a/include/configs/ml9131.h
+++ b/include/configs/ml9131.h
@@ -28,6 +28,9 @@
 #undef CONFIG_BOOTCOMMAND
 #undef CONFIG_ETHPRIME
 
+#undef TSEC2_PHY_ADDR
+#define TSEC2_PHY_ADDR		1
+
 /* disable the thermal alert for now - this needs board mods */
 #define CONFIG_ML9131_NO_THERMAL_ALERT
 


### PR DESCRIPTION
This cleans up boot output a little by defaulting to the PHY address used on 248 boards, rather than the PHY address used on 245 boards.

This means that PHY address selection will only need to invoke the fallback logic for the 245 case, which is increasingly rare.
