### PR TITLE
Revocation for ml9131 and ipa9131

### DIFF
--- a/board/ipaccess/ipa9131/Makefile
+++ b/board/ipaccess/ipa9131/Makefile
@@ -22,6 +22,7 @@ obj-y        += ipa9131.o
 obj-y        += ddr.o
 obj-y        += law.o
 obj-y        += tlb.o
+obj-$(CONFIG_FIT_REVOCATION) += revocation.o
 obj-$(CONFIG_CHARACTERISATION_IPA9131) += characterisation.o damm.o
 #obj-y		+= bsc9131rdb_mux.o
 obj-$(CONFIG_CMD_KEY)        += key.o

--- a/board/ipaccess/ipa9131/characterisation.c
+++ b/board/ipaccess/ipa9131/characterisation.c
@@ -81,8 +81,6 @@ struct characterisation_data_t
     uint8_t test_mode;
     uint8_t development_mode;
     uint8_t specials_mode;
-    uint8_t loader_revocation;
-    uint8_t application_revocation;
 };
 
 struct characterisation_data_t cdo;
@@ -159,8 +157,6 @@ void deserialise_characterisation_info(const uint8_t payload[CONFIG_CHARACTERISA
     cd->test_mode = 0;
     cd->development_mode = 0;
     cd->specials_mode = 0;
-    cd->loader_revocation = 0;
-    cd->application_revocation = 0;
 
     cd->eth0addr[0] = payload[1];
     cd->eth0addr[1] = payload[2];
@@ -301,13 +297,13 @@ int characterisation_is_specials_mode(void)
 
 u8 characterisation_loader_revocation(void)
 {
-    return cdo.loader_revocation;
+    return ipa9131_fuse_read_loader_revocation();
 }
 
 
 u8 characterisation_application_revocation(void)
 {
-    return cdo.application_revocation;
+    return ipa9131_fuse_read_application_revocation();
 }
 
 

--- a/board/ipaccess/ipa9131/image.c
+++ b/board/ipaccess/ipa9131/image.c
@@ -157,7 +157,7 @@ int load_image(unsigned int start_block, unsigned int num_blocks, unsigned int i
             }
         }
 
-        if (oper_mode != SPECIALS_MODE && fimage_table.images[i].revocation > revocation_count)
+        if (oper_mode != SPECIALS_MODE && fimage_table.images[i].revocation < revocation_count)
         {
             fimage_table.images[i].reserved = IMAGE_REVOKED_ERROR;
 

--- a/board/ipaccess/ipa9131/ipa9131.c
+++ b/board/ipaccess/ipa9131/ipa9131.c
@@ -30,7 +30,7 @@
 DECLARE_GLOBAL_DATA_PTR;
 
 #if defined(CONFIG_ML9131)
-#define ML9131_VERSION 201407001
+#define ML9131_VERSION 2014070000
 #define ML9131_REVOCATION_VALUE 0
 
 #define ml9131_macro_xstr(s) ml9131_macro_str(s)

--- a/board/ipaccess/ipa9131/ipa9131_fuse.h
+++ b/board/ipaccess/ipa9131/ipa9131_fuse.h
@@ -7,6 +7,9 @@ extern int ipa9131_fuses_are_write_protected(void);
 extern int ipa9131_fuse_should_be_silent(void);
 extern int ipa9131_fuse_read_eid(u64 * eid);
 extern int ipa9131_fuse_read_security_profile(u8 * p, u8 * d, u8 * s);
-extern int ipa9131_fuse_read_loader_revocation(u16 * r);
+extern int ipa9131_fuse_read_loader_revocation_value(u16 * r);
+extern int ipa9131_fuse_read_application_revocation_value(u32 * r);
+extern u16 ipa9131_fuse_read_loader_revocation(void);
+extern u32 ipa9131_fuse_read_application_revocation(void);
 
 #endif

--- a/board/ipaccess/ipa9131/revocation.c
+++ b/board/ipaccess/ipa9131/revocation.c
@@ -1,0 +1,11 @@
+#include <revocation.h>
+#include <common.h>
+#include "ipa9131_fuse.h"
+
+
+
+
+u64 get_board_revocation(void)
+{
+    return ipa9131_fuse_read_application_revocation();
+}


### PR DESCRIPTION
This changeset introduces revocation bit counting and value
construction for loader and application revocation.  The changeset
then builds on this functionality to do self revocation of the
ml9131 microloader, perform loader revocation checks of the load
of U-Boot from an IBN image (with corrections) and perform
fitImage revocation checks against the application revocation
from normal U-Boot.

Signed-off-by: Michael van der Westhuizen michael@smart-africa.com
