### PR TITLE
Ravindra/ipat2k parent eid

### DIFF
--- a/board/ipaccess/ipat2k/board.c
+++ b/board/ipaccess/ipat2k/board.c
@@ -404,7 +404,9 @@ void hw_watchdog_init(void)
 static void gpio_init(void)
 {
 //	REG32(GPIO_PIN_SELECT_REG1) |= I2C_SDA | I2C_SCL;
+#if defined(CONFIG_HW_WATCHDOG)
         hw_watchdog_init();
+#endif /* defined(CONFIG_HW_WATCHDOG) */
 	REG32(GPIO_PIN_SELECT_REG1) &= ~(GPIO_MUX_I2C_SCL | GPIO_MUX_I2C_SDA);	// make sure GPIO function is not selected for I2C SCL\SDA pins
 	REG32(AXI_RESET_1) &=  ~(1 << 5);
 	REG32(GPIO_PIN_SELECT_REG1) |= EXP_RDY_BSY;

--- a/board/ipaccess/ipat2k/characterisation.c
+++ b/board/ipaccess/ipat2k/characterisation.c
@@ -118,6 +118,7 @@ struct characterisation_data_t
     uint8_t app_rev_count;
     uint8_t loader_rev_count;
     uint64_t parent_serial;
+    uint8_t hwsw_compat;
 };
 
 struct characterisation_data_t cdo;
@@ -162,7 +163,7 @@ void serialise_characterisation_info_eeprom(const struct characterisation_data_t
     payload[27] = (((cd->parent_serial & 0x00FF0000) >> 16) & 0xFF);
     payload[28] = (((cd->parent_serial & 0x0000FF00) >>  8) & 0xFF);
     payload[29] = (((cd->parent_serial & 0x000000FF) >>  0) & 0xFF);
-
+    payload[30] = cd->hwsw_compat;
 
     if (cd->production_mode)
         payload[239] = 0x80;
@@ -937,6 +938,45 @@ static int parse_revocation_count(const char * revocation_count_text, uint8_t *r
     return 0;
 }
 
+
+static int parse_hwsw_compat(const char * compat_text, uint8_t * compat_number)
+{
+    char * ep;
+    unsigned long ulval;
+
+    if (!compat_text || !compat_number)
+    {
+        fprintf(stderr, "%s\n", "Invalid hwsw compatibility number: NULL argument to conversion function.");
+        return -1;
+    }
+
+    if (strlen(compat_text) > 3)
+    {
+        fprintf(stderr, "%s\n", "Invalid hwsw compatibility number: more than 3 digits in length.");
+        return -1;
+    }
+
+    errno = 0;
+    ulval = simple_strtoul(compat_text, &ep, 10);
+
+    if (ep == compat_text || *ep != '\0')
+    {
+        fprintf(stderr, "%s\n", "Invalid hwsw compatibility number: not a decimal number.");
+        return -1;
+    }
+
+
+    if ( (ulval == 0)||(ulval > 254) )
+    {
+        fprintf(stderr, "%s\n", "Invalid hwsw compatibility number: valid range is 1-254.");
+        return -1;
+    }
+
+    *compat_number = (uint8_t)ulval;
+    return 0;
+}
+
+
 static int user_input( int prompt_to_user, const char *type)
 {
     int ret = 0;
@@ -1069,8 +1109,8 @@ int characterise_fuses (const struct characterisation_data_t * cd)
         
         if (cd->app_rev_count || cd->loader_rev_count)
             ipat2k_fuse_write_revocation_counts(cd->loader_rev_count,cd->app_rev_count);
-
-	printf("\nSuccess: fuse characterisation done\n");
+        /*Do not change the text in following print, MTS expects this */
+        printf("\nSuccess: fuse characterisation done\n");
         return 0;
     }
     else
@@ -1086,29 +1126,30 @@ static int usage(const char * progname, int ret)
 {
     fprintf((ret ? stderr : stdout), "Usage: %s EEPROM -o OUI -s SERIAL_NUMBER -0 ETH0ADDR -1 ETH1ADDR -t TYPE -p PCB_ASSEMBLY_ISSUE\n", progname);
     fprintf((ret ? stderr : stdout), "Usage: %s FUSE -o OUI -s SERIAL_NUMBER -0 ETH0ADDR -1 ETH1ADDR -t TYPE -p PCB_ASSEMBLY_ISSUE\n", progname);
-    fprintf((ret ? stderr : stdout), "       -o OUI                 : Specify the OUI (part of the EID) of this board.\n");
-    fprintf((ret ? stderr : stdout), "                                This is specified as three hexadecimal octets.\n");
-    fprintf((ret ? stderr : stdout), "       -s SERIAL_NUMBER       : Specify the serial number (part of the EID, with DAMM digit) of this board.\n");
-    fprintf((ret ? stderr : stdout), "                                This is specified as a 10 digit decimal number made up of the 9\n");
-    fprintf((ret ? stderr : stdout), "                                serial number digits and 1 DAMM check digit.\n");
-    fprintf((ret ? stderr : stdout), "       -0 ETH0ADDR            : Specify the first Ethernet MAC address.\n");
-    fprintf((ret ? stderr : stdout), "                                An Ethernet address is specified as six colon separated hexadecimal octets.\n");
-    fprintf((ret ? stderr : stdout), "                                Octets are left padded to two digits with zeroes.\n");
-    fprintf((ret ? stderr : stdout), "                                For example: CA:FE:BA:BE:B0:0C.\n");
-    fprintf((ret ? stderr : stdout), "       -1 ETH1ADDR            : Specify the second Ethernet MAC address.\n");
-    fprintf((ret ? stderr : stdout), "       -t TYPE                : Specify the board type as a 16 bit decimal value (0x0000-0xFFFF).\n");
-    fprintf((ret ? stderr : stdout), "                                The TYPE argument must correspond to a known board hardware type and oscillator value.\n");
-    fprintf((ret ? stderr : stdout), "                                Unused bits must be set to 0.\n");
-    fprintf((ret ? stderr : stdout), "       -p PCB_ASSEMBLY_ISSUE  : Specify the PCB assembly issue as a 16 bit decimal value (0x0000-0xFFFF).\n");
-    fprintf((ret ? stderr : stdout), "       -m MODE                : Specify the board mode (p, t, d, s) = (production, test, development, specials).\n");
-    fprintf((ret ? stderr : stdout), "       -a APP_REV_COUNT       : Specify application revocation count as hexadecimal number (0x00-0x40) \n");
-    fprintf((ret ? stderr : stdout), "       -l LOADER_REV_COUNT    : Specify loader revocation count hexadecimal value(0x00-0x40)\n");
-    fprintf((ret ? stderr : stdout), "       -f                     : Force acceptance of a serial number that fails the DAMM algorithm check.\n");
-    fprintf((ret ? stderr : stdout), "       -no-prompt             : Do not prompt user for input before blowing the fuses (must be used when fuse blowing is done via scripts).\n");
-    fprintf((ret ? stderr : stdout), "       -dis-boot-license      : Disables boot license feature for this board\n");
-    fprintf((ret ? stderr : stdout), "       -S PARENT_SERIAL_NUMBER: Optional(EEPROM only): Specify the serial number (part of the EID, with DAMM digit) of it's parent assembly.\n");
-    fprintf((ret ? stderr : stdout), "                                This is specified as a 10 digit decimal number made up of the 9\n");
-    fprintf((ret ? stderr : stdout), "                                serial number digits and 1 DAMM check digit.\n");
+    fprintf((ret ? stderr : stdout), "       -o OUI                         : Specify the OUI (part of the EID) of this board.\n");
+    fprintf((ret ? stderr : stdout), "                                        This is specified as three hexadecimal octets.\n");
+    fprintf((ret ? stderr : stdout), "       -s SERIAL_NUMBER               : Specify the serial number (part of the EID, with DAMM digit) of this board.\n");
+    fprintf((ret ? stderr : stdout), "                                        This is specified as a 10 digit decimal number made up of the 9\n");
+    fprintf((ret ? stderr : stdout), "                                        serial number digits and 1 DAMM check digit.\n");
+    fprintf((ret ? stderr : stdout), "       -0 ETH0ADDR                    : Specify the first Ethernet MAC address.\n");
+    fprintf((ret ? stderr : stdout), "                                        An Ethernet address is specified as six colon separated hexadecimal octets.\n");
+    fprintf((ret ? stderr : stdout), "                                        Octets are left padded to two digits with zeroes.\n");
+    fprintf((ret ? stderr : stdout), "                                        For example: CA:FE:BA:BE:B0:0C.\n");
+    fprintf((ret ? stderr : stdout), "       -1 ETH1ADDR                    : Specify the second Ethernet MAC address.\n");
+    fprintf((ret ? stderr : stdout), "       -t TYPE                        : Specify the board type as a 16 bit decimal value (0x0000-0xFFFF).\n");
+    fprintf((ret ? stderr : stdout), "                                        The TYPE argument must correspond to a known board hardware type and oscillator value.\n");
+    fprintf((ret ? stderr : stdout), "                                        Unused bits must be set to 0.\n");
+    fprintf((ret ? stderr : stdout), "       -p PCB_ASSEMBLY_ISSUE          : Specify the PCB assembly issue as a 16 bit decimal value (0x0000-0xFFFF).\n");
+    fprintf((ret ? stderr : stdout), "       -m MODE                        : Specify the board mode (p, t, d, s) = (production, test, development, specials).\n");
+    fprintf((ret ? stderr : stdout), "       -a APP_REV_COUNT               : Optional(FUSES only) Specify application revocation count as hexadecimal number (0x00-0x40) \n");
+    fprintf((ret ? stderr : stdout), "       -l LOADER_REV_COUNT            : Optional(FUSES only) Specify loader revocation count hexadecimal value(0x00-0x40)\n");
+    fprintf((ret ? stderr : stdout), "       -f                             : Force acceptance of a serial number that fails the DAMM algorithm check.\n");
+    fprintf((ret ? stderr : stdout), "       -no-prompt                     : Do not prompt user for input before blowing the fuses (must be used when fuse blowing is done via scripts).\n");
+    fprintf((ret ? stderr : stdout), "       -dis-boot-license              : Disables boot license feature for this board\n");
+    fprintf((ret ? stderr : stdout), "       -S PARENT_SERIAL_NUMBER        : Optional(EEPROM only) Specify the serial number (part of the EID, with DAMM digit) of it's parent assembly.\n");
+    fprintf((ret ? stderr : stdout), "                                        This is specified as a 10 digit decimal number made up of the 9\n");
+    fprintf((ret ? stderr : stdout), "                                        serial number digits and 1 DAMM check digit. Defaults to 0000000000 if not provided\n");
+    fprintf((ret ? stderr : stdout), "       -c HWSW_COMPATIBILITY_NUMBER   : Optional(EEPROM only) Specify the hw sw compatibility number as 8 bit decimal value (1-254). Defaults to 1 if not provided.\n");
     fprintf((ret ? stderr : stdout), "\n");
     fprintf((ret ? stderr : stdout), "       This utility is only supposed to work on blank boards.\n");
     return ret;
@@ -1127,6 +1168,7 @@ int do_characterise(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
     const char * app_revocation_count_text;
     const char * loader_revocation_count_text;
     const char * parent_serial_text;
+    const char * hwsw_compat_text;
     int prod_mode;
     int test_mode;
     int dev_mode;
@@ -1139,11 +1181,13 @@ int do_characterise(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
     ret = 1;
     i = 0;
     oui_text = serial_text = eth0addr_text = eth1addr_text = type_text = pcb_assembly_issue_text = app_revocation_count_text = loader_revocation_count_text=NULL;
-    parent_serial_text=NULL;
+    parent_serial_text=hwsw_compat_text=NULL;
     prod_mode = test_mode = dev_mode = specials_mode = 0;
     ignore_damm = 0;
     prompt_to_user = 1;
     memset(&cd, 0, sizeof(cd));
+    /*hwsw_compat is optional arg, if not passed it defaults to 1*/
+    cd.hwsw_compat= 0x01;
     memset(serialised, 0, CONFIG_CHARACTERISATION_IPAT2K_SIZE);
 
     while(i < argc)
@@ -1244,6 +1288,10 @@ int do_characterise(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
         {
             parent_serial_text = argv[i+1];
         }
+        else if (0 == strcmp(argv[i],"-c"))
+        {
+            hwsw_compat_text=argv[i+1];
+        }
 
         ++i;
     }
@@ -1259,7 +1307,7 @@ int do_characterise(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
         ret = usage(argv[0], 1);
         goto cleanup;
     }
-
+    /*All mandatory parameters for both Fuses/EEPROM characterisation*/
     if (0 != parse_oui(oui_text, cd.oui) ||
         0 != parse_serial_number(serial_text, &cd.serial, ignore_damm) ||
         0 != parse_ethernet_mac_address(eth0addr_text, cd.eth0addr) ||
@@ -1271,15 +1319,6 @@ int do_characterise(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
         goto cleanup;
     }
 
-    /*optional parameters: parse if passed*/
-    if ( (loader_revocation_count_text && (0 != parse_revocation_count(loader_revocation_count_text, &cd.loader_rev_count ))) ||
-         (app_revocation_count_text && (0 != parse_revocation_count(app_revocation_count_text, &cd.app_rev_count ))) ||
-         (parent_serial_text && (0 != parse_serial_number(parent_serial_text, &cd.parent_serial, ignore_damm))) 
-        )
-    {
-        ret = usage(argv[0], 1);
-        goto cleanup;
-    }
 
 
     cd.production_mode = prod_mode ? 1 : 0;
@@ -1315,19 +1354,25 @@ int do_characterise(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
     }
     fprintf(stdout, "\n");
 
-    if (loader_revocation_count_text)
-        fprintf(stdout, "      Loader rev count: %d\n",cd.loader_rev_count);
-    
-    if (app_revocation_count_text)
-        fprintf(stdout, " Application rev count: %d\n",cd.app_rev_count);
-
-    if(cd.parent_serial)
-        fprintf(stdout, "            Parent EID: %02X%02X%02X-%010llu\n", cd.oui[0], cd.oui[1], cd.oui[2], cd.parent_serial);
-
 
 
     if (0 == strcmp(argv[1],"EEPROM"))
     {
+        /*EEPROM: optionals parse here*/
+        if ((parent_serial_text && (0 != parse_serial_number(parent_serial_text, &cd.parent_serial, ignore_damm))) ||
+           (hwsw_compat_text && (0 != parse_hwsw_compat(hwsw_compat_text, &cd.hwsw_compat))))
+        {
+            ret = usage(argv[0], 1);
+            goto cleanup;
+
+        }
+         
+        if(cd.parent_serial)
+            fprintf(stdout, "            Parent EID: %02X%02X%02X-%010llu\n", cd.oui[0], cd.oui[1], cd.oui[2], cd.parent_serial);
+        else
+            fprintf(stdout, "            Parent EID: 000000-0000000000\n");    
+
+        fprintf(stdout, "    HWSW Compatibility Number: %u\n", cd.hwsw_compat);       
 
         if ( 0 == (ret = user_input(prompt_to_user, "EEPROM")) )
         {
@@ -1346,12 +1391,27 @@ int do_characterise(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 
                 udelay(5000);
             }
+            /*Do not change the text in following print, MTS expects this exact print*/
             printf("Success: EEPROM characterisation done\n");
             ret = 0;
         }
     }
     else if (0 == strcmp(argv[1],"FUSE"))
     {
+        /*Fuses optional parameters: parse if passed*/
+        if ( (loader_revocation_count_text && (0 != parse_revocation_count(loader_revocation_count_text, &cd.loader_rev_count ))) ||
+             (app_revocation_count_text && (0 != parse_revocation_count(app_revocation_count_text, &cd.app_rev_count ))) )
+        {
+            ret = usage(argv[0], 1);
+            goto cleanup;
+        }
+        if (loader_revocation_count_text)
+            fprintf(stdout, "      Loader rev count: %d\n",cd.loader_rev_count);
+
+        if (app_revocation_count_text)
+            fprintf(stdout, " Application rev count: %d\n",cd.app_rev_count);
+
+
         if ( 0 == (ret = user_input(prompt_to_user, "FUSE")) )
             ret = characterise_fuses(&cd); 
     }
@@ -1367,7 +1427,7 @@ cleanup:
 
 
 U_BOOT_CMD(
-        characterise_hw, 21, 0, do_characterise,
+        characterise_hw, 22, 0, do_characterise,
         "Hw characterisation command to characterise board in eeprom/fuses",
         "<characterise_hw> <args>"
         );

--- a/board/ipaccess/ipat2k/characterisation.c
+++ b/board/ipaccess/ipat2k/characterisation.c
@@ -934,7 +934,7 @@ static int parse_revocation_count(const char * revocation_count_text, uint8_t *r
     }
 	
     *revocation_count = (uint8_t)(v & 0xFF);
-
+    return 0;
 }
 
 static int user_input( int prompt_to_user, const char *type)

--- a/include/configs/ipat2k_nand.h
+++ b/include/configs/ipat2k_nand.h
@@ -156,7 +156,8 @@
 #define CONFIG_CMD_LIE
 #define CONFIG_CMD_LEDSET
 #define CONFIG_CMD_LEDC
-#define CONFIG_HW_WATCHDOG
+//Keeping watchdog disabled for now, as the u-boot revision where this was added was never pulled in to yocto build.
+//#define CONFIG_HW_WATCHDOG
 
 
 #define CONFIG_ETHPRIME		"gemac1"


### PR DESCRIPTION
1) Added optional parent serial argument in characterization command. Affects only EEPROM characterization. 
2)  Disabled u-boot hw watchdog initialization as it never made it to the yocto build.